### PR TITLE
Implement SNS to SQS fanout for Scorpio broker

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -5,7 +5,7 @@
 import { Aws } from "aws-cdk-lib"
 const {version} = require('./package.json')
 
-const garnet_scorpio_version = "4.1.15"
+const garnet_scorpio_version = "4.1.16"
 
 export const garnet_bucket =  `garnet-datalake-${Aws.REGION}-${Aws.ACCOUNT_ID}` // DO NOT CHANGE
 export const garnet_broker = "Scorpio" 

--- a/lib/stacks/garnet-scorpio/fargate/index.ts
+++ b/lib/stacks/garnet-scorpio/fargate/index.ts
@@ -103,11 +103,23 @@ export class GarnetScorpioFargate extends Construct {
         fargate_task_role.addToPolicy(
             new PolicyStatement({
                 resources: [
+                    `arn:aws:sns:${Aws.REGION}:${Aws.ACCOUNT_ID}:garnet-scorpiobroker-*`
+                ],
+                actions: [
+                    "sns:*"
+                ]
+            })
+        )
+        fargate_task_role.addToPolicy(
+            new PolicyStatement({
+                resources: [
                     `*`
                 ],
                 actions: [
                     "sqs:ListQueues",
-                    "sqs:CreateQueue"
+                    "sqs:CreateQueue",
+                    "sns:ListTopics",
+                    "sns:CreateTopic"
                 ]
             })
         )


### PR DESCRIPTION
Modified the garnet framework to use the new upstream Scorpio broker version. The new version supports an SNS to SQS fanout pattern for inter-microservice messaging. This change requires new permissions for the fargate tasks so the microservices are able to manage the required SNS topics.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
